### PR TITLE
Reposition of plugin.setCaption()

### DIFF
--- a/jquery.lightbox.js
+++ b/jquery.lightbox.js
@@ -67,13 +67,12 @@
                 plugin.lightbox.fadeIn('fast').append('<span class="lightbox__loading"></span>');
 
                 var img = $('<img src="' + $(plugin.current).attr('href') + '" draggable="false">');
-
+                plugin.setCaption();
                 $(img).on('load', function () {
                     $('.lightbox__loading').remove();
                     plugin.lightbox.append(img);
                     plugin.image = $("img", plugin.lightbox).hide();
                     plugin.resizeImage();
-                    plugin.setCaption();
                 });
             },
 


### PR DESCRIPTION
The new Caption should show up immediately without waiting for its corresponding image to load.
Otherwise it would be misleading watching(reading again) the old caption while waiting for the new image to load.